### PR TITLE
Removed unsupported CODEOWNERS file.

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,0 @@
-* @az-digital/maintainers


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
The `.github/CODEOWNERS` file copied from the `az_quickstart` repo is not actually a supported GitHub community health file type so it should not have been included.

## Related Issue
#1 
